### PR TITLE
First shot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Directories
 /.vscode
+/vendor
 
 # Files
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Directories
+/.vscode
+
+# Files
+.DS_Store
+Thumbs.db

--- a/Polylang/ruleset.xml
+++ b/Polylang/ruleset.xml
@@ -37,14 +37,16 @@
 		<exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/><!-- No leading underscores for private properties. -->
 	</rule>
 
+	<!-- Run against WordPress VIP ruleset. -->
+	<!-- https://github.com/Automattic/VIP-Coding-Standards -->
+	<rule ref="WordPressVIPMinimum">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+		<exclude-pattern>*/Tests/*</exclude-pattern>
+	</rule>
+
 	<!-- Run against WordPress ruleset. -->
 	<!-- https://github.com/WordPress/WordPress-Coding-Standards -->
 	<rule ref="WordPress">
-		<!-- Set the minimum supported WP version for all sniff which use it in one go. -->
-		<!-- https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters -->
-		<properties>
-			<property name="minimum_supported_version" value="5.4"/>
-		</properties>
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 		<exclude name="PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore"/><!-- Handled by Squiz.NamingConventions.ValidFunctionName.DoubleUnderscore. -->
 		<exclude name="PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.MethodDoubleUnderscore"/><!-- Handled by WordPress.NamingConventions.ValidFunctionName.MethodDoubleUnderscore. -->
@@ -53,6 +55,18 @@
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid"/><!-- No snake case for function names. -->
 		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/><!-- No snake case for method names. -->
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+	</rule>
+	<rule ref="WordPress.PHP.NoSilencedErrors.Discouraged">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+		<exclude-pattern>*/Tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Security">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+		<exclude-pattern>*/Tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.WP.GlobalVariablesOverride">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+		<exclude-pattern>*/Tests/*</exclude-pattern>
 	</rule>
 
 	<!-- Run against the PSR-4 ruleset. -->

--- a/Polylang/ruleset.xml
+++ b/Polylang/ruleset.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Polylang" namespace="PolylangCS\Polylang" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+	<description>Coding standards for WP Syntex's plugins.</description>
+
+	<exclude-pattern>.git/*</exclude-pattern>
+	<exclude-pattern>.github/*</exclude-pattern>
+	<exclude-pattern>.wordpress-org/*</exclude-pattern>
+	<exclude-pattern>bin/*</exclude-pattern>
+	<exclude-pattern>tmp/*</exclude-pattern>
+	<exclude-pattern>vendor/*</exclude-pattern>
+
+	<!-- Run against the PHPCompatibility ruleset: PHP 5.6 and higher + WP 5.4 and higher. -->
+	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
+	<rule ref="PHPCompatibilityWP"/>
+	<config name="testVersion" value="5.6-"/>
+	<config name="minimum_supported_wp_version" value="5.4"/>
+
+	<!-- Run against custom rules. -->
+	<!-- https://github.com/squizlabs/PHP_CodeSniffer -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+	<rule ref="Generic.NamingConventions.AbstractClassNamePrefix"/>
+	<rule ref="Generic.NamingConventions.ConstructorName"/>
+	<rule ref="Generic.NamingConventions.InterfaceNameSuffix"/>
+	<rule ref="Generic.NamingConventions.TraitNameSuffix"/>
+	<rule ref="PSR2.Methods.MethodDeclaration.Underscore">
+		<type>Error</type>
+		<message>Method name "%s" must not be prefixed with an underscore</message>
+	</rule>
+	<rule ref="PSR2.Classes.PropertyDeclaration.Underscore">
+		<type>Error</type>
+		<message>Property name "%s" must not be prefixed with an underscore</message>
+	</rule>
+	<rule ref="Squiz.NamingConventions">
+		<exclude name="Squiz.NamingConventions.ValidFunctionName.PrivateNoUnderscore"/><!-- No leading underscores for private methods. -->
+		<exclude name="Squiz.NamingConventions.ValidFunctionName.MethodDoubleUnderscore"/><!-- Handled by WordPress.NamingConventions.ValidFunctionName.MethodDoubleUnderscore. -->
+		<exclude name="Squiz.NamingConventions.ValidFunctionName.PublicUnderscore"/><!-- Handled by PSR2.Methods.MethodDeclaration.Underscore. -->
+		<exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/><!-- No leading underscores for private properties. -->
+	</rule>
+
+	<!-- Run against WordPress ruleset. -->
+	<!-- https://github.com/WordPress/WordPress-Coding-Standards -->
+	<rule ref="WordPress">
+		<!-- Set the minimum supported WP version for all sniff which use it in one go. -->
+		<!-- https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#minimum-wp-version-to-check-for-usage-of-deprecated-functions-classes-and-function-parameters -->
+		<properties>
+			<property name="minimum_supported_version" value="5.4"/>
+		</properties>
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
+		<exclude name="PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.FunctionDoubleUnderscore"/><!-- Handled by Squiz.NamingConventions.ValidFunctionName.DoubleUnderscore. -->
+		<exclude name="PHPCompatibility.FunctionNameRestrictions.ReservedFunctionNames.MethodDoubleUnderscore"/><!-- Handled by WordPress.NamingConventions.ValidFunctionName.MethodDoubleUnderscore. -->
+		<exclude name="WordPress.Files.FileName"/>
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionDoubleUnderscore"/><!-- Handled by Squiz.NamingConventions.ValidFunctionName.DoubleUnderscore. -->
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid"/><!-- No snake case for function names. -->
+		<exclude name="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid"/><!-- No snake case for method names. -->
+		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
+	</rule>
+
+	<!-- Run against the PSR-4 ruleset. -->
+	<!-- https://github.com/suin/phpcs-psr4-sniff -->
+	<rule ref="Suin"/>
+	<!--
+	Put `<arg name="basepath" value="."/>` in your phpcs.xml file to indicate the location of the composer.json file.
+	-->
+</ruleset>

--- a/Polylang/ruleset.xml
+++ b/Polylang/ruleset.xml
@@ -37,13 +37,6 @@
 		<exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/><!-- No leading underscores for private properties. -->
 	</rule>
 
-	<!-- Run against WordPress VIP ruleset. -->
-	<!-- https://github.com/Automattic/VIP-Coding-Standards -->
-	<rule ref="WordPressVIPMinimum">
-		<exclude-pattern>*/tests/*</exclude-pattern>
-		<exclude-pattern>*/Tests/*</exclude-pattern>
-	</rule>
-
 	<!-- Run against WordPress ruleset. -->
 	<!-- https://github.com/WordPress/WordPress-Coding-Standards -->
 	<rule ref="WordPress">
@@ -67,6 +60,25 @@
 	<rule ref="WordPress.WP.GlobalVariablesOverride">
 		<exclude-pattern>*/tests/*</exclude-pattern>
 		<exclude-pattern>*/Tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Run against WordPress VIP ruleset. -->
+	<!-- https://github.com/Automattic/VIP-Coding-Standards -->
+	<rule ref="WordPressVIPMinimum">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+		<exclude-pattern>*/Tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Run against the NeutronStandard ruleset. -->
+	<!-- https://github.com/Automattic/phpcs-neutron-standard -->
+	<rule ref="NeutronStandard">
+		<exclude name="NeutronStandard.AssignAlign.DisallowAssignAlign.Aligned"/>
+		<exclude name="NeutronStandard.Constants.DisallowDefine.Define"/>
+		<exclude name="NeutronStandard.Functions.DisallowCallUserFunc.CallUserFunc"/>
+		<exclude name="NeutronStandard.Functions.LongFunction.LongFunction"/>
+		<exclude name="NeutronStandard.Functions.TypeHint.NoArgumentType"/>
+		<exclude name="NeutronStandard.Functions.TypeHint.NoReturnType"/>
+		<exclude name="NeutronStandard.StrictTypes.RequireStrictTypes.StrictTypes"/>
 	</rule>
 
 	<!-- Run against the PSR-4 ruleset. -->

--- a/Polylang/ruleset.xml
+++ b/Polylang/ruleset.xml
@@ -2,12 +2,12 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Polylang" namespace="PolylangCS\Polylang" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>Coding standards for WP Syntex's plugins.</description>
 
-	<exclude-pattern>.git/*</exclude-pattern>
-	<exclude-pattern>.github/*</exclude-pattern>
-	<exclude-pattern>.wordpress-org/*</exclude-pattern>
-	<exclude-pattern>bin/*</exclude-pattern>
-	<exclude-pattern>tmp/*</exclude-pattern>
-	<exclude-pattern>vendor/*</exclude-pattern>
+	<exclude-pattern>./.git/*</exclude-pattern>
+	<exclude-pattern>./.github/*</exclude-pattern>
+	<exclude-pattern>./.wordpress-org/*</exclude-pattern>
+	<exclude-pattern>./bin/*</exclude-pattern>
+	<exclude-pattern>./tmp/*</exclude-pattern>
+	<exclude-pattern>./vendor/*</exclude-pattern>
 
 	<!-- Run against the PHPCompatibility ruleset: PHP 5.6 and higher + WP 5.4 and higher. -->
 	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Set of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) rules.
 The following rulesets are included:
 
 - Several custom sniffs mainly focuse on naming conventions,
+- [NeutronStandard](https://github.com/Automattic/phpcs-neutron-standard),
 - [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) (PHP 5.6 and WP 5.4),
+- [Suin](https://github.com/suin/phpcs-psr4-sniff) (for PSR-4),
 - [WordPress](https://github.com/WordPress/WordPress-Coding-Standards),
-- [Suin](https://github.com/suin/phpcs-psr4-sniff) (for PSR-4).
+- [WordPressVIPMinimum](https://github.com/Automattic/VIP-Coding-Standards).
 
 Example for your `phpcs.xml.dist` file:
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# polylangcs
+# Polylang Coding Standards
+
+Polylang Coding Standards is a ruleset for code quality tools to be used in WP Syntex's projects.
+
+## Installation
+
+Standards are provided as a [Composer](https://getcomposer.org/) package and can be installed with:
+
+```bash
+composer require --dev wpsyntex/polylang-cs:^1.0
+```
+
+## PHP Code Sniffer
+
+Set of [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) rules.
+
+The following rulesets are included:
+
+- Several custom sniffs mainly focuse on naming conventions,
+- [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) (PHP 5.6 and WP 5.4),
+- [WordPress](https://github.com/WordPress/WordPress-Coding-Standards),
+- [Suin](https://github.com/suin/phpcs-psr4-sniff) (for PSR-4).
+
+Example for your `phpcs.xml.dist` file:
+
+```xml
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Polylang Foobar" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+    <description>Coding standards for Polylang Foobar.</description>
+
+    <arg value="p"/><!-- Shows progress. -->
+    <arg name="colors"/><!-- Shows results with colors. -->
+    <arg name="extensions" value="php"/><!-- Limits to PHP files. -->
+
+    <file>.</file>
+
+    <!-- Our own ruleset. -->
+    <rule ref="Polylang">
+        <exclude name="Squiz.PHP.CommentedOutCode.Found"/>
+        <exclude name="WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize"/>
+    </rule>
+
+    <!-- Run against the PSR-4 ruleset. -->
+    <!-- https://github.com/suin/phpcs-psr4-sniff -->
+    <arg name="basepath" value="."/>
+</ruleset>
+```

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "wpsyntex/composer-cs",
+	"name": "wpsyntex/polylang-cs",
 	"description": "Coding standards for WP Syntex's plugins",
 	"license": "MIT",
 	"homepage": "https://github.com/polylang/polylang-cs",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+	"name": "wpsyntex/composer-cs",
+	"description": "Coding standards for WP Syntex's plugins",
+	"license": "MIT",
+	"homepage": "https://github.com/polylang/polylang-cs",
+	"type": "phpcodesniffer-standard",
+	"config": {
+		"sort-packages": true
+	},
+	"require": {
+		"dealerdirect/phpcodesniffer-composer-installer": "*",
+		"phpcompatibility/phpcompatibility-wp": "^2.1",
+		"roave/security-advisories": "dev-master",
+		"squizlabs/php_codesniffer": "^3.6",
+		"suin/phpcs-psr4-sniff": "^3.0",
+		"wp-coding-standards/wpcs": "^2.3"
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
 		"sort-packages": true
 	},
 	"require": {
+		"automattic/phpcs-neutron-standard": "*",
 		"automattic/vipwpcs": "*",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
 		"sort-packages": true
 	},
 	"require": {
+		"automattic/vipwpcs": "*",
 		"dealerdirect/phpcodesniffer-composer-installer": "*",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"roave/security-advisories": "dev-master",


### PR DESCRIPTION
The following rulesets are included:

- Several custom sniffs mainly focuse on naming conventions,
- [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) (PHP 5.6 and WP 5.4),
- [WordPress](https://github.com/WordPress/WordPress-Coding-Standards),
- [Suin](https://github.com/suin/phpcs-psr4-sniff) (for PSR-4).

Some folders and files are excluded by default.
By default, PHPCompatibility will test agaisnt PHP 5.6 and WP 5.4.