### PR TITLE
Removed unnecessary exclude patterns for test folders

### DIFF
--- a/Polylang/ruleset.xml
+++ b/Polylang/ruleset.xml
@@ -50,22 +50,18 @@
 		<exclude name="WordPress.NamingConventions.ValidVariableName"/>
 	</rule>
 	<rule ref="WordPress.PHP.NoSilencedErrors.Discouraged">
-		<exclude-pattern>*/tests/*</exclude-pattern>
 		<exclude-pattern>*/Tests/*</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.Security">
-		<exclude-pattern>*/tests/*</exclude-pattern>
 		<exclude-pattern>*/Tests/*</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.WP.GlobalVariablesOverride">
-		<exclude-pattern>*/tests/*</exclude-pattern>
 		<exclude-pattern>*/Tests/*</exclude-pattern>
 	</rule>
 
 	<!-- Run against WordPress VIP ruleset. -->
 	<!-- https://github.com/Automattic/VIP-Coding-Standards -->
 	<rule ref="WordPressVIPMinimum">
-		<exclude-pattern>*/tests/*</exclude-pattern>
 		<exclude-pattern>*/Tests/*</exclude-pattern>
 	</rule>
 


### PR DESCRIPTION
Since exclude patterns are not case sensitive, there are no needs for 2 patterns with different cases.