### PR TITLE
Allow tests' set_up*() methods in snake case

### DIFF
--- a/Polylang/Sniffs/NamingConventions/ValidFunctionNameSniff.php
+++ b/Polylang/Sniffs/NamingConventions/ValidFunctionNameSniff.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Ensures method names are correct.
+ * php version 5.6
+ *
+ * @package WP_Syntex\PolylangCS
+ */
+
+namespace WP_Syntex\PolylangCS\Polylang\Sniffs\NamingConventions;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Standards\Squiz\Sniffs\NamingConventions\ValidFunctionNameSniff as SquizValidFunctionNameSniff;
+use PHP_CodeSniffer\Util\Common;
+
+/**
+ * Sniff that ensures method names are correct.
+ * This version allows to ignore some method names that are imposed to us.
+ */
+class ValidFunctionNameSniff extends SquizValidFunctionNameSniff {
+
+	/**
+	 * Method names to ignore.
+	 *
+	 * @var array<string>
+	 */
+	public $ignoreMethods = [
+		'set_up_before_class',
+		'set_up',
+		'assert_pre_conditions',
+		'assert_post_conditions',
+		'tear_down',
+		'tear_down_after_class',
+	];
+
+	/**
+	 * Processes the tokens within the scope.
+	 *
+	 * @param  File $phpcsFile The file being processed.
+	 * @param  int  $stackPtr  The position where this token was found.
+	 * @param  int  $currScope The position of the current scope.
+	 * @return void
+	 */
+	protected function processTokenWithinScope( File $phpcsFile, $stackPtr, $currScope ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// Determine if this is a function which needs to be examined.
+		$conditions = $tokens[ $stackPtr ]['conditions'];
+		end( $conditions );
+		$deepestScope = key( $conditions );
+
+		if ( $deepestScope !== $currScope ) {
+			return;
+		}
+
+		$methodName = $phpcsFile->getDeclarationName( $stackPtr );
+
+		if ( null === $methodName ) {
+			// Ignore closures.
+			return;
+		}
+
+		if ( in_array( $methodName, $this->ignoreMethods, true ) ) {
+			return;
+		}
+
+		parent::processTokenWithinScope( $phpcsFile, $stackPtr, $currScope );
+	}
+}

--- a/Polylang/ruleset.xml
+++ b/Polylang/ruleset.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Polylang" namespace="PolylangCS\Polylang" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Polylang" namespace="WP_Syntex\PolylangCS\Polylang" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
 	<description>Coding standards for WP Syntex's plugins.</description>
 
 	<exclude-pattern>./.git/*</exclude-pattern>
@@ -42,11 +42,19 @@
 		<type>Error</type>
 		<message>Property name "%s" must not be prefixed with an underscore</message>
 	</rule>
-	<rule ref="Squiz.NamingConventions">
-		<exclude name="Squiz.NamingConventions.ValidFunctionName.PrivateNoUnderscore"/><!-- No leading underscores for private methods. -->
-		<exclude name="Squiz.NamingConventions.ValidFunctionName.MethodDoubleUnderscore"/><!-- Handled by WordPress.NamingConventions.ValidFunctionName.MethodDoubleUnderscore. -->
-		<exclude name="Squiz.NamingConventions.ValidFunctionName.PublicUnderscore"/><!-- Handled by PSR2.Methods.MethodDeclaration.Underscore. -->
-		<exclude name="Squiz.NamingConventions.ValidVariableName.PrivateNoUnderscore"/><!-- No leading underscores for private properties. -->
+	<rule ref="Polylang.NamingConventions">
+		<exclude name="Polylang.NamingConventions.ValidFunctionName.PrivateNoUnderscore"/><!-- No leading underscores for private methods. -->
+		<exclude name="Polylang.NamingConventions.ValidFunctionName.MethodDoubleUnderscore"/><!-- Handled by WordPress.NamingConventions.ValidFunctionName.MethodDoubleUnderscore. -->
+		<exclude name="Polylang.NamingConventions.ValidFunctionName.PublicUnderscore"/><!-- Handled by PSR2.Methods.MethodDeclaration.Underscore. -->
+		<exclude name="Polylang.NamingConventions.ValidVariableName.PrivateNoUnderscore"/><!-- No leading underscores for private properties. -->
+	</rule>
+	<rule ref="Polylang.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
+		<include-pattern>Tests/*</include-pattern>
+		<include-pattern>UnitTests/*</include-pattern>
+	</rule>
+	<rule ref="Squiz.NamingConventions.ValidFunctionName.ScopeNotCamelCaps">
+		<exclude-pattern>Tests/*</exclude-pattern>
+		<exclude-pattern>UnitTests/*</exclude-pattern>
 	</rule>
 
 	<!-- Run against WordPress ruleset. -->


### PR DESCRIPTION
This creates a new sniff, based on `Squiz.NamingConventions.ValidFunctionName`, that allows some methods to be ignored. This sniff checks that our methods are in camelCase but allows a given list of names in snake_case.
I was aiming for this list to be customizable within `ruleset.xml` but for an unknown reason, this doesn't seem to work, so the method names are directly listed in the sniff, in a public class property.
As a result, this sniff is used only in the "tests" folder, and the original sniff everywhere else.
The methods to ignore are: `set_up_before_class()`, `set_up()`, `assert_pre_conditions()`, `assert_post_conditions()`, `tear_down()`, and `tear_down_after_class()`.