### PR TITLE
Proposed changes after WPML to Polylang dev

### DIFF
--- a/Polylang/ruleset.xml
+++ b/Polylang/ruleset.xml
@@ -9,11 +9,13 @@
 	<exclude-pattern>./tmp/*</exclude-pattern>
 	<exclude-pattern>./vendor/*</exclude-pattern>
 
-	<!-- Run against the PHPCompatibility ruleset: PHP 5.6 and higher + WP 5.4 and higher. -->
+	<!-- Run against the PHPCompatibility ruleset.-->
 	<!-- https://github.com/PHPCompatibility/PHPCompatibilityWP -->
 	<rule ref="PHPCompatibilityWP"/>
-	<config name="testVersion" value="5.6-"/>
-	<config name="minimum_supported_wp_version" value="5.4"/>
+	<!--
+	Put `<config name="testVersion" value="5.6-"/>` in your phpcs.xml file to indicate the min PHP version.
+	Put `<config name="minimum_supported_wp_version" value="5.4"/>` in your phpcs.xml file to indicate the min WP version.
+	-->
 
 	<!-- Run against generic formatting rules. -->
 	<!-- https://github.com/squizlabs/PHP_CodeSniffer -->
@@ -21,10 +23,14 @@
 	<rule ref="Generic.WhiteSpace.IncrementDecrementSpacing"/>
 	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
 	<rule ref="PEAR.Commenting.FileComment.MissingVersion"/>
-	<rule ref="PEAR.Functions.FunctionDeclaration.SpaceAfterFunction"/>
+	<rule ref="PEAR.Functions.FunctionDeclaration.SpaceAfterFunction">
+		<exclude-pattern>*.js</exclude-pattern>
+	</rule>
 	<rule ref="Squiz.Commenting.LongConditionClosingComment.Missing"/>
 	<rule ref="Squiz.ControlStructures.SwitchDeclaration.MissingDefault"/>
-	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction"/>
+	<rule ref="Squiz.Functions.MultiLineFunctionDeclaration.SpaceAfterFunction">
+		<exclude-pattern>*.js</exclude-pattern>
+	</rule>
 	<rule ref="Squiz.PHP.GlobalKeyword.NotAllowed"/>
 	<rule ref="Squiz.WhiteSpace.ControlStructureSpacing.NoLineAfterClose"/>
 

--- a/Polylang/ruleset.xml
+++ b/Polylang/ruleset.xml
@@ -6,6 +6,7 @@
 	<exclude-pattern>./.github/*</exclude-pattern>
 	<exclude-pattern>./.wordpress-org/*</exclude-pattern>
 	<exclude-pattern>./bin/*</exclude-pattern>
+	<exclude-pattern>./node_modules/*</exclude-pattern>
 	<exclude-pattern>./tmp/*</exclude-pattern>
 	<exclude-pattern>./vendor/*</exclude-pattern>
 


### PR DESCRIPTION
For the [complete refactor of WPML to Polylang](https://github.com/polylang/wpml-to-polylang/pull/19), I'm using this package. Here is my feedback:
- I propose to let min PHP and WP versions be decided by each project.
- Two rules are not meaningful for js files, so I propose to exclude them.
